### PR TITLE
Parse comments from file

### DIFF
--- a/nhtiledit.js
+++ b/nhtiledit.js
@@ -793,6 +793,8 @@ function nh_parse_text_tiles(data)
             if (tilenum < tmp_tiles.length) {
                 console.log("WARNING: Tile #" + tilenum + " already exists.");
             }
+        } else if (!in_tile && line.startsWith("#")) {
+            continue;
         } else if (!in_tile && line == "{") {
             in_tile = 1;
         } else if (in_tile && line.match(re_tiledata)) {


### PR DESCRIPTION
Don't choke and die when a file includes random comments (which are now 
allowed in the format).  Keep track of tile-specific comments and 
include them in output.

I don't know if that second part is really necessary (and the 
implementation is a bit janky, I feel) so potentially could discard the
second commit and use only the first one.

Example of a tile with comments:
![Screen Shot 2023-01-25 at 8 31 02 PM](https://user-images.githubusercontent.com/40038830/214735924-5de8a2bd-e747-4e05-b114-ce8028fa9c74.png)